### PR TITLE
Added DataCollector & Updated required version of PHP & Elastica

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -30,7 +30,7 @@ class Client extends BaseClient
     public function request($path, $method = Request::GET, $data = array(), array $query = array())
     {
         if ($this->stopwatch) {
-            $this->stopwatch->start('es_request', 'fos_elastica');
+            $this->stopwatch->start('es_request', 'snowcap_elastica');
         }
         $start = microtime(true);
         $response = parent::request($path, $method, $data, $query);

--- a/Client.php
+++ b/Client.php
@@ -3,7 +3,75 @@
 namespace Snowcap\ElasticaBundle;
 
 use Elastica\Client as BaseClient;
+use Elastica\Request;
+use Snowcap\ElasticaBundle\Logger\ElasticaLogger;
+use Symfony\Component\Stopwatch\Stopwatch;
 
-class Client extends BaseClient {
+/**
+ * Class Client
+ * @package Snowcap\ElasticaBundle
+ */
+class Client extends BaseClient
+{
+    /**
+     * Symfony's debugging Stopwatch.
+     *
+     * @var Stopwatch|null
+     */
+    private $stopwatch;
 
+    /**
+     * @param string $path
+     * @param string $method
+     * @param array $data
+     * @param array $query
+     * @return \Elastica\Response
+     */
+    public function request($path, $method = Request::GET, $data = array(), array $query = array())
+    {
+        if ($this->stopwatch) {
+            $this->stopwatch->start('es_request', 'fos_elastica');
+        }
+        $start = microtime(true);
+        $response = parent::request($path, $method, $data, $query);
+        $this->logQuery($path, $method, $data, $query, $start);
+        if ($this->stopwatch) {
+            $this->stopwatch->stop('es_request');
+        }
+        return $response;
+    }
+    /**
+     * Sets a stopwatch instance for debugging purposes.
+     *
+     * @param Stopwatch $stopwatch
+     */
+    public function setStopwatch(Stopwatch $stopwatch = null)
+    {
+        $this->stopwatch = $stopwatch;
+    }
+
+    /**
+     * Log the query if we have an instance of ElasticaLogger.
+     *
+     * @param string $path
+     * @param string $method
+     * @param array  $data
+     * @param array  $query
+     * @param int    $start
+     */
+    private function logQuery($path, $method, $data, array $query, $start)
+    {
+        if (!$this->_logger or !$this->_logger instanceof ElasticaLogger) {
+            return;
+        }
+        $time = microtime(true) - $start;
+        $connection = $this->getLastRequest()->getConnection();
+        $connection_array = array(
+            'host'      => $connection->getHost(),
+            'port'      => $connection->getPort(),
+            'transport' => $connection->getTransport(),
+            'headers'   => $connection->hasConfig('headers') ? $connection->getConfig('headers') : array(),
+        );
+        $this->_logger->logQuery($path, $method, $data, $time, $connection_array, $query);
+    }
 }

--- a/DataCollector/ElasticaDataCollector.php
+++ b/DataCollector/ElasticaDataCollector.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Snowcap\ElasticaBundle\DataCollector;
+
+use Snowcap\ElasticaBundle\Logger\ElasticaLogger;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Class ElasticaDataCollector
+ * @package Snowcap\ElasticaBundle\DataCollector
+ */
+class ElasticaDataCollector extends DataCollector
+{
+    protected $logger;
+
+    public function __construct(ElasticaLogger $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function collect(Request $request, Response $response, \Exception $exception = null)
+    {
+        $this->data['nb_queries'] = $this->logger->getNbQueries();
+        $this->data['queries'] = $this->logger->getQueries();
+    }
+
+    /**
+     * @return int
+     */
+    public function getQueryCount()
+    {
+        return $this->data['nb_queries'];
+    }
+
+    /**
+     * @return array
+     */
+    public function getQueries()
+    {
+        return $this->data['queries'];
+    }
+
+    /**
+     * @return int
+     */
+    public function getTime()
+    {
+        $time = 0;
+        foreach ($this->data['queries'] as $query) {
+            $time += $query['executionMS'];
+        }
+
+        return $time;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'elastica';
+    }
+}

--- a/Logger/ElasticaLogger.php
+++ b/Logger/ElasticaLogger.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Snowcap\ElasticaBundle\Logger;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class ElasticaLogger
+ * @package FOS\ElasticaBundle\Logger
+ */
+class ElasticaLogger implements LoggerInterface
+{
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @var array
+     */
+    protected $queries = array();
+
+    /**
+     * @var boolean
+     */
+    protected $debug;
+
+    /**
+     * Constructor.
+     *
+     * @param LoggerInterface|null $logger The Symfony logger
+     * @param boolean              $debug
+     */
+    public function __construct(LoggerInterface $logger = null, $debug = false)
+    {
+        $this->logger = $logger;
+        $this->debug = $debug;
+    }
+
+    /**
+     * Logs a query.
+     *
+     * @param string $path       Path to call
+     * @param string $method     Rest method to use (GET, POST, DELETE, PUT)
+     * @param array  $data       Arguments
+     * @param float  $time       Execution time
+     * @param array  $connection Host, port, transport, and headers of the query
+     * @param array  $query      Arguments
+     */
+    public function logQuery($path, $method, $data, $time, $connection = array(), $query = array())
+    {
+        if ($this->debug) {
+            $this->queries[] = array(
+                'path' => $path,
+                'method' => $method,
+                'data' => $data,
+                'executionMS' => $time,
+                'connection' => $connection,
+                'queryString' => $query,
+            );
+        }
+
+        if (null !== $this->logger) {
+            $message = sprintf("%s (%s) %0.2f ms", $path, $method, $time * 1000);
+            $this->logger->info($message, (array) $data);
+        }
+    }
+
+    /**
+     * Returns the number of queries that have been logged.
+     *
+     * @return integer The number of queries logged
+     */
+    public function getNbQueries()
+    {
+        return count($this->queries);
+    }
+
+    /**
+     * Returns a human-readable array of queries logged.
+     *
+     * @return array An array of queries
+     */
+    public function getQueries()
+    {
+        return $this->queries;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function emergency($message, array $context = array())
+    {
+        return $this->logger->emergency($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function alert($message, array $context = array())
+    {
+        return $this->logger->alert($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function critical($message, array $context = array())
+    {
+        return $this->logger->critical($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function error($message, array $context = array())
+    {
+        return $this->logger->error($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warning($message, array $context = array())
+    {
+        return $this->logger->warning($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function notice($message, array $context = array())
+    {
+        return $this->logger->notice($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function info($message, array $context = array())
+    {
+        return $this->logger->info($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function debug($message, array $context = array())
+    {
+        return $this->logger->debug($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function log($level, $message, array $context = array())
+    {
+        return $this->logger->log($level, $message, $context);
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -9,11 +9,27 @@ services:
         calls:
             - [setContainer, [ @service_container ]]
             - [setIndexes, [ %snowcap_elastica.indexes% ]]
+
     snowcap_elastica.client:
         class: Snowcap\ElasticaBundle\Client
         arguments: [%snowcap_elastica.config%]
+        calls:
+            - [setLogger, [ @snowcap_elastica.logger ]]
+
     snowcap_elastica.subscriber:
         class: Snowcap\ElasticaBundle\Listener\IndexSubscriber
         arguments: [@snowcap_elastica.service]
         tags:
             - { name: doctrine.event_subscriber }
+
+    snowcap_elastica.logger:
+        class: Snowcap\ElasticaBundle\Logger\ElasticaLogger
+        arguments: [ @logger, %kernel.debug% ]
+        tags:
+            - { name: monolog.logger, channel: elastica }
+
+    snowcap_elastica.data_collector:
+        class: Snowcap\ElasticaBundle\DataCollector\ElasticaDataCollector
+        arguments: [ @snowcap_elastica.logger ]
+        tags:
+            - { name: data_collector, template: "SnowcapElasticaBundle:Collector:elastica", id: "elastica" }

--- a/Resources/views/Collector/elastica.html.twig
+++ b/Resources/views/Collector/elastica.html.twig
@@ -1,0 +1,106 @@
+{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+
+{% block toolbar %}
+    {% set icon %}
+    <img alt="elastica" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABYAAAAcCAYAAABlL09dAAAABGdBTUEAALGPC/xhBQAAA/BpQ0NQSUNDIFByb2ZpbGUAACiRjVXdb9tUFD+Jb1ykFj+gsY4OFYuvVVNbuRsarcYGSZOl6UIauc3YKqTJdW4aU9c2ttNtVZ/2Am8M+AOAsgcekHhCGgzE9rLtAbRJU0EV1SSkPXTaQGiT9oKqcK6vU7tdxriRr38553c+79E1QMdXmuOYSRlg3vJdNZ+Rj5+YljtWIQnPQSf0QKeme066XC4CLsaFR9bDXyHB3jcH2uv/c3VWqacDJJ5CbFc9fR7xaYCUqTuuDyDeRvnwKd9B3PE84h0uJohYYXiW4yzDMxwfDzhT6ihilouk17Uq4iXE/TMx+WwM8xyCtSNPLeoausx6UXbtmmHSWLpPUP/PNW82WvF68eny5iaP4ruP1V53x9QQf65ruUnELyO+5vgZJn8V8b3GXCWNeC9A8pmae6TC+ck3FutT7yDeibhq+IWpUL5ozZQmuG1yec4+qoaca7o3ij2DFxHfqtNCkecjQJVmc6xfiHvrjbHQvzDuLUzmWn4W66Ml7kdw39PGy4h7EH/o2uoEz1lYpmZe5f6FK45fDnMQ1i2zVOQ+iUS9oMZA7tenxrgtOeDjIXJbMl0zjhRC/pJjBrOIuZHzbkOthJwbmpvLcz/kPrUqoc/UrqqWZb0dRHwYjiU0oGDDDO46WLABMqiQhwy+HXBRUwMDTJRQ1FKUGImnYQ5l7XnlgMNxxJgNrNeZNUZpz+ER7oQcm3QThezH5yApkkNkmIyATN4kb5HDJIvSEXJw07Yci89i3dn08z400CvjHYPMuZ5GXxTvrHvS0K9/9PcWa/uRnGkrn3gHwMMOtJgD8fqvLv2wK/KxQi68e7Pr6hJMPKm/qdup9dQK7quptYiR+j21hr9VSGNuZpDRPD5GkIcXyyBew2V8fNBw/wN5doy3JWLNOtcTaVgn6AelhyU42x9Jld+UP5UV5QvlvHJ3W5fbdkn4VPhW+FH4Tvhe+Blk4ZJwWfhJuCJ8I1yMndXj52Pz7IN6W9UyTbteUzCljLRbeknKSi9Ir0jFyJ/ULQ1JY9Ie1OzePLd4vHgtBpzAvdXV9rE4r4JaA04FFXhBhy04s23+Q2vSS4ZIYdvUDrNZbjHEnJgV0yCLe8URcUgcZ7iVn7gHdSO457ZMnf6YCmiMFa9zIJg6NqvMeiHQeUB9etpnF+2o7Zxxjdm6L+9TlNflNH6qqFyw9MF+WTNNOVB5sks96i7Q6iCw7yC/oh+owfctsfN6JPPfBjj0F95ZNyLZdAPgaw+g+7VI1od34rOfAVw4oDfchfDOTyR+AfBq+/fxf10ZvJtuNZsP8L7q+ARg4+Nm85/lZnPjS/S/BnDJ/BdZAHF4xCjCQAAAAAlwSFlzAAALEwAACxMBAJqcGAAABWZJREFUSIm1lU9sXFcVxr9773tv/o8n5sWeGQejTIwpoXYlUCQCUiBSRTdRpS5ihLKxiJBASBFVkViwiOpNxCYREixSdimoi0pATAQJEkJIDlWUtK5K4iKc1HatYtfO+N+8PzPvvnMOCzyWxy2BBT2bK7177u9+99N331Uigk+i9CdCBeD8L00TExOmr6/PN8Z83RjzLaXUF40xeQBzxpjfWGt/6/v+BxcvXky6a9R/s+LChQuZKIqe1Vr/SGv9FaVUopRKjTGitTZa64zW+j2l1BXP816/dOnShojIExVPTEyYUqn0nIhcBjDkuu7Dcrm8UC6XN7XWAuBQq9UaDsNwGMDLcRwXJycnfwag/URwqVT6DIApAJ/O5XKzjUbjzVqttt3f30+FQqFQ7is7YRAuz87OBvPz858noheLxeIbAG7vgZVS6sSJE4Ou646naZoS0ZtjY2PnAIx7nvePkZGRuyMjI9uFQgHZbFZXKpXC4ODgEc/z6gMDA+udTuf9hYWFUQAvAbi9l4qTJ09mtdaTzHwFwA8ymcxRpdQLRESVSuXdI0eObBeLReV5nvI8T4hoKwzDOcdxglqtdvj48eM7xpiAmZ8D9sWNiPIATouIEpE/VKtVF8CA1jqsVCrNUqkkruvC8zxorZVSKu10Oh9GUfQ2gG3f97czmUyLiHIHwUpEHBGZ1Vr/rlgspsYY7bqudV03dRwHWmtoreE4DjzPg+M4ipmb1tp3rbUrImKJCD3gbjFzGoahFZEPRMSKSCZN0ywRGWOM6kK76gFEYRgubG5u2iRJvI+AjTEiIujm+tq1a2tJkiwxcyGKouFsNlvNZDL5/aodxwEAabfbvLS0NBAEwSHP8zZ6wMxcIyKfiGg3o4jj+GqSJMna2trxxcXFwU6nUxCR/WtkZ2cHc3Nz/qNHj55SSmWLxeIvgH1XmpmnRMRn5ncAhLvg3wO4wczP37lz5wsbGxtJo9EIqtVqEIYhOp2ONz8/X7t///4zGxsbjVKp9FYul3vlILifiDqppK04iAkAbty4sXnmzJmXHccZbTabY3Ecl5eXl4/29/dvGWMkCILC2tracBzHh/L5/N9c150aHx9/vwdsrf2xiPwcgi87jjMNoA0Ap06dsq1WC4uLi6rVapWTJPlss9l0RUSladoGsGqM+SOAV9M0nTl79iz1gIno70qpx0TkEZEGgNOnTzvHjh37dqFQeMpxHCRJ8ra1dpqEjFHGYebtlZUVLwiCpa2trfcePnyYXL58GQetUAAUM+9Fr16vP9PpdL63tbXlRVG0w8yvlcvlq5wwcqWcevDgQd/CwsJPiei7InKrUqlMAVjqAQdBgFwuh/1gAD9JkqQUxzGCIHij3W7/6ubNm0F3slqtMhH9GcBRpdRXd8dlEeGeC9LNsO/76ty5c5NKqS/FcSxRFK1aa1+9e/fuh/v7V1dXw2azeVVEfikiqYiY7lwPmIhARHz+/PmjtVrtO9baviiK0G63b1trb8nHvwqamYmZsyIy1HXhoGIhIp3L5b4xOjr6ucP+YeW67rq19pV79+49/hgoAKQiMiciLWZ+qVAo9Pd4vKtYMTNmZmbeqdfrfzKOebbRaPzadd2Z/wD9NzlNZXcD0lrzR8Ddf8X169f/Wq/X79dqtemxsbG3pqenoydwDTM/LSKfAjAVRdEWsO8xHRoa8kXkdRF5rJT64crKyj8BqCcp3a2s53kvisg3ReT7aZr+RUR4T3Gr1ZJ8Pp+IyEkRueL7figiB+OH7jdrLUQEROQw89NEJCKSdvv2wMPDw6319fVbAL4G4PnuSbTWezHsWsXMXSiYGUTEAF4D8EhEuMeK/3f9C5VtKG2arhqTAAAAAElFTkSuQmCC" />
+    <span class="sf-toolbar-status">{{ collector.querycount }}</span>
+    {% if collector.querycount > 0 %}
+        <span class="sf-toolbar-info-piece-additional-detail">in {{ '%0.2f'|format(collector.time * 1000) }} ms</span>
+    {% endif %}
+    {% endset %}
+    {% set text %}
+    <div class="sf-toolbar-info-piece">
+        <b>Queries</b>
+        <span>{{ collector.querycount }}</span>
+    </div>
+    <div class="sf-toolbar-info-piece">
+        <b>Query Time</b>
+        <span>{{ '%0.2f'|format(collector.time * 1000) }} ms</span>
+    </div>
+    {% endset %}
+    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
+{% endblock %}
+
+{% block menu %}
+    <span class="label">
+        <span class="icon"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABYAAAAcCAQAAADPJofWAAAAAXNSR0IArs4c6QAAAAJiS0dEAP+Hj8y/AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH2woEDg0xnxGaxwAAA51JREFUOMt100ts1FUUx/Hvufc/8x9mOrTTDpbysEVsqTzUqAsRgpqQGIJiIhtZSEJcqNGFJrSiZSPYkKALBUyAiLEuWKjBhdFAaEwwPNQqEAgEaA0FEWh4lE477/+9x0WLsST+Fmf1ycnJvecI/0knW4ENgZkhr5gVMtcEMmB64z1msCOCboR70tlkOuQdQREMBovF7tQt71/mXtzZQo8s89jLycFETiSqKd/v5wSY32VN18Ak3JGiR1d7an+Y3Z/Np7yVeCY/9czU4efF2iPxZ+wLXPgXP7WCTZ7MvvlnZlbqSJnGGbMeam5pk6HTIw9qs7tiH6D9vrbXW9e1Tus/sbhHZ8VOtfU1uZSExCUe1ExLtqayjcPnx4qNssjOs3TQrY9rYdVB2aFRw7HWq2kbJxCjFAsDoY+3hbkbw9ebNBsQ6EJVNlb3yQIDY8lcaAIsBisxiSXGToTNWqi/JUWXMIoabrK/95ymDNYHzmDUYAiwWOImOle+EI2AxyiKVydQGVAIoyneiBUNsAQEWIn+LA2NJqOYw3hUFQV2DFbu+FSuKTk9kRGMBoyPE7m8vza7UhMrmQNlV+NwAlDZXmXkkcHaeNamQBCEiLyeb7w631C71yxfr8/6YT8GUP6ifKlcf3xJX26kWNQyJfL+TvVs3S8rCw31hfRm2/KzL+iGQz8BnLjz8EVd5TPXF9wI/E0ZK/gr6SOLj7+Yz9RRu2bmMXm6y2/0A/rS0f6JL985+prVQAJiKEU8kLid6ezaA8Gh7iVP6BKtHad7njQr+xmSeFELLi2YovwlJ5Nbu07DNoLFoVNVrwBvh6feSMwSDcVuLvWF0y3Brd9mDlRlTsuVweGPCRzI+NOBW2rW3iYv5ZPfbrm7ji2fx1/Vkn7U/OGlivE4HA5Yh+yqUKFAYa3QfXcVf/R7Segy3wDGo4x3Tr3H3LLmqX6mZ5+jC4A5DO7jLR3SmAoYj8eTqx5uMR+UKErp78q2/e7ARNuLgE940bR1E9jpcKx+16MxJUd5+68XJp+a5DnqFxU/yYZG8XiSfJ+awkIW9WW+zLF8sh6NeqJb0cs+biIcKjW8u3T3xj+uZXZ/PbSe3km2nHWbogb3ZlSgPWz/bt71tsf432Qa64bSh5PTIFAU0pqdG3oRIiCgBBgsVTwRpYwmnWgMAlUd1aR+6m+DA4QqBlDKRDgifCqq8WO+CoFW9Ctd7dvBA+NV8DgiognuSv4bbsA/e9y1PQRZggAAAAAASUVORK5CYII=" alt="" /></span>
+        <strong>Elastica</strong>
+        <span class="count">
+            <span>{{ collector.querycount }}</span>
+            <span>{{ '%0.0f'|format(collector.time * 1000) }} ms</span>
+        </span>
+    </span>
+{% endblock %}
+
+{% block panel %}
+    <h2>Queries</h2>
+
+    {% if not collector.queries %}
+        <p>
+            <em>Query logging is disabled.</em>
+        <p>
+    {% elseif not collector.querycount %}
+        <p>
+            <em>No queries.</em>
+        </p>
+    {% else %}
+        <ul class="alt">
+            {% for key, query in collector.queries %}
+                <li class="{{ cycle(['odd', 'even'], loop.index) }}">
+                    <strong>Path</strong>: {{ query.path }}<br />
+                    <strong>Query</strong>: {{ query.queryString|url_encode }}<br />
+                    <strong>Method</strong>: {{ query.method }} <small>({{ query.connection.transport }} on {{ query.connection.host }}:{{ query.connection.port }})</small>
+                    <small>
+                        <strong>Time</strong>: {{ '%0.2f'|format(query.executionMS * 1000) }} ms
+                    </small>
+
+                    <br />
+                    <a href="#elastica_json_{{ key }}" onclick="return toggle(this);" style="text-decoration: none;">
+                        <img alt="+" src="{{ asset('bundles/framework/images/blue_picto_more.gif') }}" style="display: inline; width: 12px; height: 12px; vertical-align: bottom;" />
+                        <img alt="-" src="{{ asset('bundles/framework/images/blue_picto_less.gif') }}" style="display: none; width: 12px; height: 12px; vertical-align: bottom;" />
+                        <small>Display JSON query</small>
+                    </a>
+
+                    <div id="elastica_json_{{ key }}" style="display: none;">
+                        <pre><code>{{ query.data|json_encode(constant('JSON_PRETTY_PRINT')) }}</code></pre>
+                    </div>
+
+                    {% if query.connection.transport in ['Http', 'Https'] %}
+                        <br />
+                        <a href="#elastica_curl_query_{{ key }}" onclick="return toggle(this);" style="text-decoration: none;">
+                            <img alt="+" src="{{ asset('bundles/framework/images/blue_picto_more.gif') }}" style="display: inline; width: 12px; height: 12px; vertical-align: bottom;" />
+                            <img alt="-" src="{{ asset('bundles/framework/images/blue_picto_less.gif') }}" style="display: none; width: 12px; height: 12px; vertical-align: bottom;" />
+                            <small>Display cURL query</small>
+                        </a>
+
+                        <div style="display: none;" id="elastica_curl_query_{{ key }}">
+                            <code>curl -X{{ query.method }} '{{ query.connection.transport|lower }}://{{ query.connection.host }}:{{ query.connection.port }}/{{ query.path }}{% if query.queryString|length %}?{{ query.queryString|url_encode }}{% endif %}' -d '{{ query.data|json_encode }}'</code>
+                        </div>
+                    {% endif %}
+                </li>
+            {% endfor %}
+        </ul>
+
+        <script type="text/javascript">//<![CDATA[
+            function toggle(link) {
+                "use strict";
+
+                var sections = link.children;
+
+                if (sections[0].style.display != 'none') {
+                    sections[0].style.display = 'none';
+                    sections[1].style.display = 'inline';
+
+                    document.getElementById(link.hash.replace("#", "")).style.display = 'block';
+                } else {
+                    sections[0].style.display = 'inline';
+                    sections[1].style.display = 'none';
+
+                    document.getElementById(link.hash.replace("#", "")).style.display = 'none';
+                }
+
+                return false;
+            }
+        </script>
+    {% endif %}
+{% endblock %}

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.2",
-        "ruflin/elastica": "1.3.4.0"
+        "php": ">=5.4.*",
+        "ruflin/elastica": "1.4.3.0"
     },
     "require-dev": {
         "symfony/symfony": "2.6.*",


### PR DESCRIPTION
As the constant used in the template file of the data collector requires at least PHP 5.4, I had to update the min version for PHP.
The elastica version has been updated too as it matches the changes made for the 1.4.x version of elasticsearch.
